### PR TITLE
feat: #3 make math.calc more reusable

### DIFF
--- a/src/arr/index.test.ts
+++ b/src/arr/index.test.ts
@@ -43,6 +43,13 @@ describe("arr", () => {
     expect(arr.fill(2, "a")).toStrictEqual(["a", "a"]);
   });
 
+  it("from", () => {
+    expect.assertions(2);
+
+    expect(arr.from(3, (i) => i < 2)).toStrictEqual([true, true, false]);
+    expect(arr.from(4, (i) => i % 2)).toStrictEqual([0, 1, 0, 1]);
+  });
+
   it("group", () => {
     expect.assertions(1);
 

--- a/src/math/calc.ts
+++ b/src/math/calc.ts
@@ -1,27 +1,29 @@
 import { from } from "../arr/from";
+import { unapply } from "../func/unapply";
 import type { Calc, Quantity } from "./types";
 
-const calc = <A extends Quantity[]>(
-  opFn: (...a: number[]) => number,
-  ...arr: A
-): Calc<A> => {
-  if (arr.length !== opFn.length) {
-    throw Error("Input array and operation function must have same length");
-  }
-  const vectors = arr.filter((el) => typeof el !== "number") as number[][];
-  if (vectors.length === 0) {
-    return opFn.apply(undefined, arr as number[]) as Calc<A>;
-  }
-  const size = vectors[0].length;
-  if (vectors.some((v) => v.length !== size)) {
-    throw Error("All vectors must have same length");
-  }
-  return from(size, (i) => {
-    const input: number[] = arr.map((el) => {
-      return typeof el === "number" ? el : el[i];
-    });
-    return opFn.apply(undefined, input);
-  }) as Calc<A>;
+const calc = (
+  opFn: (...a: number[]) => number
+): (<A extends Quantity[]>(...args: A) => Calc<A>) => {
+  return unapply(<A extends Quantity[]>(arr: A) => {
+    if (arr.length < opFn.length) {
+      throw Error("Input array and operation function must have same length");
+    }
+    const vectors = arr.filter((el) => typeof el !== "number") as number[][];
+    if (vectors.length === 0) {
+      return opFn.apply(undefined, arr as number[]) as Calc<A>;
+    }
+    const size = vectors[0].length;
+    if (vectors.some((v) => v.length !== size)) {
+      throw Error("All vectors must have same length");
+    }
+    return from(size, (i) => {
+      const input: number[] = arr.map((el) => {
+        return typeof el === "number" ? el : el[i];
+      });
+      return opFn.apply(undefined, input);
+    }) as Calc<A>;
+  });
 };
 
 export { calc };

--- a/src/math/index.test.ts
+++ b/src/math/index.test.ts
@@ -12,12 +12,12 @@ describe("math", () => {
   it("calc", () => {
     expect.assertions(6);
 
-    expect(() => math.calc((a, b, x) => a * x + b, 1, 2)).toThrow();
-    expect(() => math.calc((a, b) => a + b, [1, 2], [3])).toThrow();
-    expect(math.calc((a, b) => a + b, 1, 2)).toBe(3);
-    expect(math.calc((a) => a - 1, [3])).toStrictEqual([2]);
-    expect(math.calc((a, b) => a + b, 1, [2, 3])).toStrictEqual([3, 4]);
-    expect(math.calc((a, b, x) => a * b + x, [1, 2], 3, 4)).toStrictEqual([
+    expect(() => math.calc((a, b, x) => a * x + b)(1, 2)).toThrow();
+    expect(() => math.calc((a, b) => a + b)([1, 2], [3])).toThrow();
+    expect(math.calc((a, b) => a + b)(1, 2, 3)).toBe(3);
+    expect(math.calc((a) => a - 1)([3])).toStrictEqual([2]);
+    expect(math.calc((a, b) => a + b)(1, [2, 3])).toStrictEqual([3, 4]);
+    expect(math.calc((a, b, x) => a * b + x)([1, 2], 3, 4)).toStrictEqual([
       7, 10
     ]);
   });


### PR DESCRIPTION
- Ask opFn only and return func that operates a given arr
- Adjust calc tests
- Add arr.from test