### PR TITLE
feat: #29 add obj.omit

### DIFF
--- a/src/obj/index.test.ts
+++ b/src/obj/index.test.ts
@@ -105,6 +105,13 @@ describe("obj", () => {
     expect(union.birth).not.toBe(person.birth);
   });
 
+  it("omit", () => {
+    expect.assertions(1);
+
+    const omitted = obj.omit(person, ["birth", "id"]);
+    expect(omitted).toStrictEqual({ name: person.name });
+  });
+
   it("vals", () => {
     expect.assertions(2);
 

--- a/src/obj/index.ts
+++ b/src/obj/index.ts
@@ -5,4 +5,5 @@ export * from "./has";
 export * from "./isObj";
 export * from "./keys";
 export * from "./merge";
+export * from "./omit";
 export * from "./vals";

--- a/src/obj/omit.ts
+++ b/src/obj/omit.ts
@@ -1,0 +1,9 @@
+import { copy } from "./copy";
+
+export const omit = <T, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> => {
+  const newObj = copy(obj);
+  for (const key of keys) {
+    delete newObj[key];
+  }
+  return newObj;
+};


### PR DESCRIPTION
Add an `obj.omit` to copy object omitting given properties