### PR TITLE
feat: add arr.find

### DIFF
--- a/src/arr/find.ts
+++ b/src/arr/find.ts
@@ -1,0 +1,13 @@
+export const find = <T>(
+  arr: T[],
+  predicate: (val: T, idx: number, obj: T[]) => boolean,
+  from = 0,
+  to = arr.length
+): T | undefined => {
+  for (let i = from; i < to; i++) {
+    if (predicate(arr[i], i, arr)) {
+      return arr[i];
+    }
+  }
+  return undefined;
+};

--- a/src/arr/findIdx.ts
+++ b/src/arr/findIdx.ts
@@ -1,0 +1,13 @@
+export const findIdx = <T>(
+  arr: T[],
+  predicate: (val: T, idx: number, obj: T[]) => boolean,
+  from = 0,
+  to = arr.length
+): number => {
+  for (let i = from; i < to; i++) {
+    if (predicate(arr[i], i, arr)) {
+      return i;
+    }
+  }
+  return -1;
+};

--- a/src/arr/index.test.ts
+++ b/src/arr/index.test.ts
@@ -43,6 +43,22 @@ describe("arr", () => {
     expect(arr.fill(2, "a")).toStrictEqual(["a", "a"]);
   });
 
+  it("find", () => {
+    expect.assertions(2);
+
+    expect(arr.find(balls, ({ name }) => name === "Baseball")).toStrictEqual(
+      balls[0]
+    );
+    expect(arr.find(balls, ({ name }) => name === "Soccer")).toBeUndefined();
+  });
+
+  it("findIdx", () => {
+    expect.assertions(2);
+
+    expect(arr.findIdx(balls, ({ name }) => name === "Baseball")).toBe(0);
+    expect(arr.findIdx(balls, ({ name }) => name === "Soccer")).toBe(-1);
+  });
+
   it("from", () => {
     expect.assertions(2);
 

--- a/src/arr/index.ts
+++ b/src/arr/index.ts
@@ -1,5 +1,7 @@
 export * from "./chunk";
 export * from "./fill";
+export * from "./find";
+export * from "./findIdx";
 export * from "./from";
 export * from "./group";
 export * from "./groupBy";


### PR DESCRIPTION
add `arr.find` and `arr.findIdx` to get the first element matching a given condition. They allow to limit the search between "from" and "to" indexes, half-inclusive