### PR TITLE
feat: math utils improvements

### DIFF
--- a/src/arr/types.ts
+++ b/src/arr/types.ts
@@ -1,1 +1,11 @@
 export type Predicate<T, R = boolean> = (val: T, idx: number, arr: T[]) => R;
+
+export type Tuple<
+  T,
+  N extends number,
+  R extends T[] = []
+> = R["length"] extends N ? R : Tuple<T, N, [...R, T]>;
+
+export type ConvertTuple<T, ToType> = {
+  [K in keyof T]: ToType;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * as arr from "arr";
+export * from "arr/types";
 export * as func from "func";
 export * as math from "math";
 export * as obj from "obj";

--- a/src/math/calc.ts
+++ b/src/math/calc.ts
@@ -1,28 +1,24 @@
 import { from } from "arr/from";
+import type { ConvertTuple } from "arr/types";
 import { unapply } from "func/unapply";
 
 import type { Calc, Quantity } from "./types";
 
-export const calc = (
-  opFn: (...a: number[]) => number
-): (<A extends Quantity[]>(...args: A) => Calc<A>) => {
-  return unapply(<A extends Quantity[]>(arr: A) => {
-    if (arr.length < opFn.length) {
-      throw Error("Input array and operation function must have same length");
-    }
+export const calc = <T extends number[], A extends ConvertTuple<T, Quantity>>(
+  opFn: (...nums: T) => number
+): ((...q: A) => Calc<A>) => {
+  return unapply((arr) => {
     const vectors = arr.filter((el) => typeof el !== "number") as number[][];
     if (vectors.length === 0) {
-      return opFn.apply(undefined, arr as number[]) as Calc<A>;
+      return opFn.apply(undefined, arr as unknown as T) as Calc<A>;
     }
     const size = vectors[0].length;
     if (vectors.some((v) => v.length !== size)) {
       throw Error("All vectors must have same length");
     }
     return from(size, (i) => {
-      const input: number[] = arr.map((el) => {
-        return typeof el === "number" ? el : el[i];
-      });
-      return opFn.apply(undefined, input);
+      const input = arr.map((el) => (typeof el === "number" ? el : el[i]));
+      return opFn.apply(undefined, input as T);
     }) as Calc<A>;
   });
 };

--- a/src/math/divide.ts
+++ b/src/math/divide.ts
@@ -1,5 +1,3 @@
-import { multiply } from "./multiply";
+import { calc } from "./calc";
 
-export const divide = (arr: number[], n: number): number[] => {
-  return multiply(arr, 1 / n);
-};
+export const divide = calc((a, b) => a / b);

--- a/src/math/index.test.ts
+++ b/src/math/index.test.ts
@@ -3,11 +3,10 @@ import * as math from ".";
 
 describe("math", () => {
   it("add", () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
-    const arr = [-4, 1, 0, 3, 2];
-    const exp = [1, 6, 5, 8, 7];
-    expect(math.add(arr, 5)).toStrictEqual(exp);
+    expect(math.add([-4, 1, 0, 3, 2], 5)).toStrictEqual([1, 6, 5, 8, 7]);
+    expect(math.add([1, 2], [3, 4])).toStrictEqual([4, 6]);
   });
 
   it("aprox", () => {
@@ -19,12 +18,12 @@ describe("math", () => {
   });
 
   it("calc", () => {
-    expect.assertions(6);
+    expect.assertions(4);
 
-    expect(() => math.calc((a, b, x) => a * x + b)(1, 2)).toThrow();
-    expect(() => math.calc((a, b) => a + b)([1, 2], [3])).toThrow();
-    expect(math.calc((a, b) => a + b)(1, 2, 3)).toBe(3);
-    expect(math.calc((a) => a - 1)([3])).toStrictEqual([2]);
+    expect(() => math.calc((a, b) => a + b)([1, 2], [3])).toThrow(
+      "All vectors must have same length"
+    );
+    expect(math.calc((a) => a - 1)(3)).toStrictEqual(2);
     expect(math.calc((a, b) => a + b)(1, [2, 3])).toStrictEqual([3, 4]);
     expect(math.calc((a, b, x) => a * b + x)([1, 2], 3, 4)).toStrictEqual([
       7, 10
@@ -39,11 +38,10 @@ describe("math", () => {
   });
 
   it("divide", () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
-    const arr = [-4, 1, 0, 3, 2];
-    const exp = [-2, 0.5, 0, 1.5, 1];
-    expect(math.divide(arr, 2)).toStrictEqual(exp);
+    expect(math.divide([-4, 1, 0, 3], 2)).toStrictEqual([-2, 0.5, 0, 1.5]);
+    expect(math.divide([1, 2], [3, 4])).toStrictEqual([1 / 3, 0.5]);
   });
 
   it("inRange", () => {
@@ -76,7 +74,7 @@ describe("math", () => {
     expect(math.mean(nums, [1, 1, 1, 1, 1])).toBe(2 / 5);
     expect(() => math.mean(nums, [1, 1, 1, 1])).toThrow();
     const meanw = math.mean(nums, [1, 2, 3, 4, 5]);
-    expect(math.aprox(meanw, 20 / 15)).toBe(true);
+    expect(meanw).toBe(20 / 15);
   });
 
   it("median", () => {
@@ -154,11 +152,10 @@ describe("math", () => {
   });
 
   it("subtract", () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
-    const arr = [-4, 1, 0, 3, 2];
-    const exp = [-5, 0, -1, 2, 1];
-    expect(math.subtract(arr, 1)).toStrictEqual(exp);
+    expect(math.subtract([-4, 1, 0, 3, 2], 1)).toStrictEqual([-5, 0, -1, 2, 1]);
+    expect(math.subtract([1, 2], [3, 4])).toStrictEqual([-2, -2]);
   });
 
   it("sum", () => {

--- a/src/math/interp.ts
+++ b/src/math/interp.ts
@@ -5,12 +5,11 @@ export const interp = (x: number[], xp: number[], fp: number[]): number[] => {
     throw new Error("xp and fp must have the same length");
   }
 
-  let i = 0;
   return x.map((xi) => {
     if (xi >= xp[xp.length - 1]) {
       return fp[fp.length - 1];
     }
-    i = findIdx(xp, (el) => el >= xi, i);
+    const i = findIdx(xp, (el) => el >= xi);
     if (i === 0) {
       return fp[0];
     }

--- a/src/math/multiply.ts
+++ b/src/math/multiply.ts
@@ -3,7 +3,5 @@ import { unapply } from "func/unapply";
 import { calc } from "./calc";
 
 export const multiply = calc(
-  unapply((arr) => {
-    return arr.reduce((acc, el) => acc * el, 1);
-  })
+  unapply((arr: number[]) => arr.reduce((acc, el) => acc * el, 1))
 );

--- a/src/math/pow.ts
+++ b/src/math/pow.ts
@@ -1,3 +1,3 @@
-export const pow = (arr: number[], n: number): number[] => {
-  return arr.map((el) => Math.pow(el, n));
+export const pow = (arr: number[], exp: number): number[] => {
+  return arr.map((el) => Math.pow(el, exp));
 };

--- a/src/math/round.ts
+++ b/src/math/round.ts
@@ -1,13 +1,13 @@
 import type { Quantity } from "./types";
 
-const _round = (num: number, n: number): number => {
-  const k = Math.pow(10, n);
-  return Math.round(num * k) / k;
+const _round = (n: number, p: number): number => {
+  const k = Math.pow(10, p);
+  return Math.round(n * k) / k;
 };
 
-export const round = <T extends Quantity>(num: T, n = 0): T => {
-  if (typeof num === "number") {
-    return _round(num, n) as T;
+export const round = <T extends Quantity>(q: T, precision = 0): T => {
+  if (typeof q === "number") {
+    return _round(q, precision) as T;
   }
-  return num.map((el) => _round(el, n)) as T;
+  return q.map((el) => _round(el, precision)) as T;
 };

--- a/src/math/subtract.ts
+++ b/src/math/subtract.ts
@@ -1,5 +1,3 @@
-import { add } from "./add";
+import { calc } from "./calc";
 
-export const subtract = (arr: number[], n: number): number[] => {
-  return add(arr, -n);
-};
+export const subtract = calc((a, b) => a - b);


### PR DESCRIPTION
- add arr type Tuple for custom tuple size
- add arr type ConvertTuple to change the elements type of a tuple
- make math.calc type more strict for tuples
- add support for quantities in math.divide & math.subtract by using calc
- remove from math.interp the assumption that "x" arg is sorted
- rename some math utils args for better readability